### PR TITLE
Add dynamic navigation menu and dark theme

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2,8 +2,8 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: #0f172a;
-  background-color: #f1f5f9;
+  color: #e2e8f0;
+  background-color: #020617;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -19,7 +19,8 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: #f1f5f9;
+  background: radial-gradient(circle at top, rgba(30, 41, 59, 0.65), rgba(2, 6, 23, 0.95));
+  color: #e2e8f0;
 }
 
 a {
@@ -37,7 +38,7 @@ button {
 #app {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 3rem 1.5rem;
+  padding: 4rem 1.5rem 3rem;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add a fixed dynamic navigation menu that lists the remaining secciones and a Home link
- refresh the Finanzas view with a dark themed palette and updated component styling
- update global styles to support the new dark background treatment

## Testing
- npm run build *(fails: electron-builder cannot download Electron binaries in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e66538f730832db277746ff35943f4