### PR TITLE
Improve finance view contrast and interactions

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -19,7 +19,10 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(30, 41, 59, 0.65), rgba(2, 6, 23, 0.95));
+  background:
+    radial-gradient(circle at 18% 15%, rgba(37, 99, 235, 0.35), transparent 55%),
+    radial-gradient(circle at 82% 0%, rgba(14, 165, 233, 0.28), transparent 52%),
+    linear-gradient(180deg, #020617 0%, #0f172a 40%, #020617 100%);
   color: #e2e8f0;
 }
 


### PR DESCRIPTION
## Summary
- refresh the global background gradient to provide stronger contrast behind the finance screens
- update landing cards and detail headers with luminous icon treatments and an overlay panel to focus the active section
- allow users to close the detail panel by pressing Escape or clicking outside the card to return to the home view

## Testing
- npm run build *(fails: electron binary download is forbidden in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e667a2cc58832d9b4f741c14accb02