### PR TITLE
Integrate external finance endpoints and markdown categories

### DIFF
--- a/src/services/cartera.ts
+++ b/src/services/cartera.ts
@@ -1,0 +1,12 @@
+import { http } from './http'
+import type { Registro, RegistroPayload } from './tipos'
+
+const RECURSO = '/cartera'
+
+export const listarCartera = () => http<Registro[]>(RECURSO)
+
+export const crearCartera = (payload: RegistroPayload) =>
+  http<Registro>(RECURSO, {
+    method: 'POST',
+    body: payload
+  })

--- a/src/services/categorias.ts
+++ b/src/services/categorias.ts
@@ -1,0 +1,6 @@
+import { http } from './http'
+import type { Categoria } from './tipos'
+
+const RECURSO = '/categorias'
+
+export const listarCategorias = () => http<Categoria[]>(RECURSO)

--- a/src/services/egresos.ts
+++ b/src/services/egresos.ts
@@ -1,0 +1,12 @@
+import { http } from './http'
+import type { Registro, RegistroPayload } from './tipos'
+
+const RECURSO = '/egresos'
+
+export const listarEgresos = () => http<Registro[]>(RECURSO)
+
+export const crearEgreso = (payload: RegistroPayload) =>
+  http<Registro>(RECURSO, {
+    method: 'POST',
+    body: payload
+  })

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,0 +1,65 @@
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3000/api'
+
+type JsonBody = Record<string, unknown> | unknown[] | object
+
+type HttpOptions = Omit<RequestInit, 'body'> & {
+  body?: BodyInit | JsonBody | null
+}
+
+const normalizarUrl = (path: string) => {
+  const base = API_BASE_URL.replace(/\/$/, '')
+  const recurso = path.startsWith('/') ? path : `/${path}`
+  return `${base}${recurso}`
+}
+
+const prepararBody = (body: HttpOptions['body'], headers: Headers) => {
+  if (body == null) {
+    return undefined
+  }
+
+  if (
+    typeof body === 'string' ||
+    body instanceof FormData ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body as ArrayBufferView) ||
+    body instanceof URLSearchParams ||
+    (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream)
+  ) {
+    return body as BodyInit
+  }
+
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  return JSON.stringify(body)
+}
+
+export async function http<T>(path: string, options: HttpOptions = {}): Promise<T> {
+  const headers = new Headers(options.headers ?? {})
+  const body = prepararBody(options.body, headers)
+
+  const respuesta = await fetch(normalizarUrl(path), {
+    ...options,
+    headers,
+    body
+  })
+
+  if (!respuesta.ok) {
+    const detalle = await respuesta.text().catch(() => '')
+    throw new Error(detalle || `Error ${respuesta.status} al llamar ${path}`)
+  }
+
+  if (respuesta.status === 204) {
+    return undefined as T
+  }
+
+  const tipoContenido = respuesta.headers.get('Content-Type') ?? ''
+
+  if (tipoContenido.includes('application/json')) {
+    return (await respuesta.json()) as T
+  }
+
+  return (await respuesta.text()) as T
+}

--- a/src/services/ingresos.ts
+++ b/src/services/ingresos.ts
@@ -1,0 +1,12 @@
+import { http } from './http'
+import type { Registro, RegistroPayload } from './tipos'
+
+const RECURSO = '/ingresos'
+
+export const listarIngresos = () => http<Registro[]>(RECURSO)
+
+export const crearIngreso = (payload: RegistroPayload) =>
+  http<Registro>(RECURSO, {
+    method: 'POST',
+    body: payload
+  })

--- a/src/services/tipos.ts
+++ b/src/services/tipos.ts
@@ -1,0 +1,25 @@
+export type TipoRegistro = 'ingresos' | 'egresos' | 'cartera'
+
+export interface Registro {
+  id: number
+  monto: number
+  categoriaId: number
+  fecha: string
+  notas: string
+  categoriaMarkdown?: string | null
+}
+
+export interface RegistroPayload {
+  monto: number
+  categoriaId: number
+  fecha: string
+  notas: string
+  categoriaMarkdown?: string | null
+}
+
+export interface Categoria {
+  id: number
+  nombre: string
+  tipo: TipoRegistro
+  markdown: string
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,28 @@
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+export const renderMarkdown = (markdown: string): string => {
+  const limpio = escapeHtml(markdown)
+
+  const conEnlaces = limpio.replace(
+    /\[(.+?)\]\((https?:\/\/[^\s)]+)\)/g,
+    '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>'
+  )
+
+  const conNegritas = conEnlaces
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/__(.+?)__/g, '<strong>$1</strong>')
+
+  const conCursivas = conNegritas
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/_(.+?)_/g, '<em>$1</em>')
+
+  const conCodigo = conCursivas.replace(/`([^`]+)`/g, '<code>$1</code>')
+
+  return conCodigo.replace(/\r?\n/g, '<br />')
+}


### PR DESCRIPTION
## Summary
- add a shared HTTP helper and service modules for ingresos, egresos, cartera y categorías so the UI can talk to external endpoints
- refactor FinanzasView to cargar información desde el backend, seleccionar categorías desde la base de datos y mostrar el contenido como Markdown
- crear un utilitario ligero para renderizar Markdown y mejorar estilos/estados del formulario y la lista

## Testing
- npm run build *(fails: electron-builder cannot download Electron binaries in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e72f697cfc832d9929b58dbb0d6d3c